### PR TITLE
chore: add .gitignore for recon output dirs and sensitive config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Recon output directories created during tool execution
+SUB_HUNT/
+URL_HUNT/
+DIR_HUNT/
+PORT_HUNT/
+403_HUNT/
+ORG_HUNT/
+NUCLEI_HUNT/
+
+# Tool output and temporary files
+*.txt
+!wordlist/*.txt
+*.log
+*.csv
+*.json
+*.xml
+*.html
+
+# Config with secrets (API keys, Telegram tokens)
+conf.zsh
+
+# Common system files
+.DS_Store
+Thumbs.db
+*~
+
+# Go binaries (if tools are built locally)
+*.exe
+*.out
+
+# Python artifacts (if any helper scripts added)
+__pycache__/
+*.pyc
+.venv/


### PR DESCRIPTION
HuntTheBug generates several output directories during recon runs (`SUB_HUNT/`, `URL_HUNT/`, `DIR_HUNT/`, etc.) and these shouldn't end up in git. More importantly, `conf.zsh` holds Telegram bot tokens and API keys — also shouldn't be committed.

**What this adds:**
- Ignores all tool-generated output directories (`*_HUNT/`)
- Excludes `conf.zsh` (contains secrets/API keys)
- Ignores loose `.txt`/`.log`/`.json` output files while keeping `wordlist/*.txt`
- Standard OS and editor cruft (`.DS_Store`, `~` swap files)